### PR TITLE
Valueless keys

### DIFF
--- a/src/v2/build.rs
+++ b/src/v2/build.rs
@@ -15,8 +15,8 @@ pub struct Build {
 
     /// Build arguments.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty",
-            deserialize_with = "deserialize_map_or_key_value_list")]
-    pub args: BTreeMap<String, RawOr<String>>,
+            deserialize_with = "deserialize_map_or_key_optional_value_list")]
+    pub args: BTreeMap<String, Option<RawOr<String>>>,
 
     /// PRIVATE.  Mark this struct as having unknown fields for future
     /// compatibility.  This prevents direct construction and exhaustive
@@ -98,7 +98,7 @@ dockerfile: Dockerfile
     let build: Build = serde_yaml::from_str(yaml).unwrap();
     assert_eq!(build.context, value(Context::new(".")));
     assert_eq!(build.dockerfile, Some(value("Dockerfile".to_owned())));
-    assert_eq!(build.args.get("key").expect("wanted key 'key'").value().unwrap(),
+    assert_eq!(build.args.get("key").expect("wanted key 'key'").as_ref().unwrap().value().unwrap(),
                "value");
 }
 
@@ -115,16 +115,16 @@ args:
     let build: Build = serde_yaml::from_str(yaml).unwrap();
 
     // Check type conversion.
-    assert_eq!(build.args.get("bool").expect("wanted key 'bool'").value().unwrap(),
+    assert_eq!(build.args.get("bool").expect("wanted key 'bool'").as_ref().unwrap().value().unwrap(),
                "true");
-    assert_eq!(build.args.get("float").expect("wanted key 'float'").value().unwrap(),
+    assert_eq!(build.args.get("float").expect("wanted key 'float'").as_ref().unwrap().value().unwrap(),
                "1.5");
-    assert_eq!(build.args.get("int").expect("wanted key 'int'").value().unwrap(),
+    assert_eq!(build.args.get("int").expect("wanted key 'int'").as_ref().unwrap().value().unwrap(),
                "1");
 
     // Check interpolation.
     let mut interp: RawOr<String> =
-        build.args.get("interp").expect("wanted key 'interp'").to_owned();
+        build.args.get("interp").expect("wanted key 'interp'").as_ref().unwrap().to_owned();
     env::set_var("FOO", "foo");
     let env = OsEnvironment::new();
     assert_eq!(interp.interpolate_env(&env).unwrap(), "foo")
@@ -136,14 +136,10 @@ fn build_args_may_be_a_key_value_list() {
 context: .
 args:
   - key=value
+  - other_key
 ";
     let build: Build = serde_yaml::from_str(yaml).unwrap();
-    assert_eq!(build.args.get("key").expect("should have key").value().unwrap(),
+    assert_eq!(build.args.get("key").expect("should have key").as_ref().unwrap().value().unwrap(),
                "value");
+    assert_eq!(*build.args.get("other_key").expect("should have other_key"), None);
 }
-
-// TODO MED: Implement valueless keys.
-//
-// args:
-//   - buildno
-//   - password

--- a/src/v2/helpers.rs
+++ b/src/v2/helpers.rs
@@ -95,7 +95,7 @@ impl<'de> Deserialize<'de> for ConvertToString {
 ///
 /// ```text
 /// struct Example {
-///     #[serde(deserialize_with = "deserialize_hash_or_key_value_list")]
+///     #[serde(deserialize_with = "deserialize_map_or_key_value_list")]
 ///     pub args: BTreeMap<String, RawOr<String>>,
 /// }
 /// ```

--- a/src/v2/helpers.rs
+++ b/src/v2/helpers.rs
@@ -165,7 +165,7 @@ where
         }
     }
 
-    deserializer.deserialize_map(MapOrKeyValueListVisitor)
+    deserializer.deserialize_any(MapOrKeyValueListVisitor)
 }
 
 /// Like `deserialize_map_or_key_value_list`, but allowing missing values
@@ -241,7 +241,7 @@ where
         }
     }
 
-    deserializer.deserialize_map(MapOrKeyOptionalValueListVisitor)
+    deserializer.deserialize_any(MapOrKeyOptionalValueListVisitor)
 }
 
 /// Given a map, deserialize it normally.  But if we have a list of string
@@ -287,7 +287,7 @@ where
         }
     }
 
-    deserializer.deserialize_map(MapOrDefaultListVisitor(PhantomData::<T>))
+    deserializer.deserialize_any(MapOrDefaultListVisitor(PhantomData::<T>))
 }
 
 /// Deserialize either list or a single bare string as a list.

--- a/src/v2/network.rs
+++ b/src/v2/network.rs
@@ -39,8 +39,8 @@ pub struct Network {
     /// Docker labels for this volume, specifying various sorts of
     /// custom metadata.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty",
-            deserialize_with = "deserialize_map_or_key_value_list")]
-    pub labels: BTreeMap<String, RawOr<String>>,
+            deserialize_with = "deserialize_map_or_key_optional_value_list")]
+    pub labels: BTreeMap<String, Option<RawOr<String>>>,
 
     // TODO LOW: ipam
 

--- a/src/v2/service.rs
+++ b/src/v2/service.rs
@@ -98,8 +98,8 @@ pub struct Service {
     /// Docker labels for this container, specifying various sorts of
     /// custom metadata.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty",
-            deserialize_with = "deserialize_map_or_key_value_list")]
-    pub labels: BTreeMap<String, RawOr<String>>,
+            deserialize_with = "deserialize_map_or_key_optional_value_list")]
+    pub labels: BTreeMap<String, Option<RawOr<String>>>,
 
     /// Links to other services in this file.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/v2/service.rs
+++ b/src/v2/service.rs
@@ -305,9 +305,7 @@ impl Service {
         let mut new_env = BTreeMap::new();
         for rel_path in &self.env_files {
             let env_file = EnvFile::load(&base.join(&rel_path.value()?))?;
-            new_env.extend(env_file.to_environment()?
-                           .into_iter()
-                           .map(|(k, v)| (k, Some(v))));
+            new_env.append(&mut env_file.to_environment()?);
         }
         new_env.append(&mut self.environment.clone());
         self.environment = new_env;

--- a/src/v2/volume.rs
+++ b/src/v2/volume.rs
@@ -31,8 +31,8 @@ pub struct Volume {
     /// Docker labels for this volume, specifying various sorts of
     /// custom metadata.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty",
-            deserialize_with = "deserialize_map_or_key_value_list")]
-    pub labels: BTreeMap<String, RawOr<String>>,
+            deserialize_with = "deserialize_map_or_key_optional_value_list")]
+    pub labels: BTreeMap<String, Option<RawOr<String>>>,
 
     /// PRIVATE.  Mark this struct as having unknown fields for future
     /// compatibility.  This prevents direct construction and exhaustive


### PR DESCRIPTION
In `environment` sections you can specify valueless keys like

```yaml
environment:
  - FOO
  - BAR
```

And docker-compose will pick up the relevant values on the machine compose runs on.

The other form,

```yaml
environment:
  FOO:
  BAR:
```

would require serde_yaml changes, I believe.