### PR TITLE
Add healthcheck config opiton

### DIFF
--- a/src/v2/health_check.rs
+++ b/src/v2/health_check.rs
@@ -1,0 +1,40 @@
+// This is not a normal Rust module! It's included directly into v2.rs,
+// possibly after build-time preprocessing.  See v2.rs for an explanation
+// of how this works.
+
+/// Settings for performing health checks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthCheck {
+    /// The command to run to perform the health check.
+    pub test: CommandLine,
+
+    /// Interval between health checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval: Option<String>,
+
+    /// How long health checks are retried.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<String>,
+
+    /// Number of times to retry health checks
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retries: Option<u32>,
+
+    /// Time to wait before counting any failed checks against total 
+    /// number of retries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_period: Option<String>,
+
+
+    /// PRIVATE.  Mark this struct as having unknown fields for future
+    /// compatibility.  This prevents direct construction and exhaustive
+    /// matching.  This needs to be be public because of
+    /// http://stackoverflow.com/q/39277157/12089
+    #[doc(hidden)]
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub _hidden: (),
+}
+
+derive_standard_impls_for!(HealthCheck, {
+    test, interval, timeout, retries, start_period, _hidden
+});

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -86,6 +86,7 @@ include!("network.rs");
 include!("build.rs");
 include!("context.rs");
 include!("extends.rs");
+include!("health_check.rs");
 include!("logging.rs");
 include!("network_interface.rs");
 include!("port_mapping.rs");

--- a/src/v2/service.rs
+++ b/src/v2/service.rs
@@ -91,6 +91,10 @@ pub struct Service {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_hosts: Vec<RawOr<HostMapping>>,
 
+    /// Settings for running health checks on services.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub healthcheck: Option<HealthCheck>,
+
     /// The name of the image to build or pull for this container.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<RawOr<Image>>,
@@ -265,6 +269,7 @@ derive_standard_impls_for!(Service, {
     extends,
     external_links,
     extra_hosts,
+    healthcheck,
     image,
     labels,
     links,


### PR DESCRIPTION
Note: this is only compatible with docker-compose v2.1+

And that brings up an interesting question: do we want to start being smarter about how compose_yml handles docker-compose.yml versions? That is, instead of having the v2 module support 2.0+, have separate modules for v2.0, v2.1, v3.0, etc?

One idea here might be to add a `compose_yml::File` module that can intelligently load whichever version of `File` we need for the `version` specified in the yml file.