### PR TITLE
Add target option to build block

### DIFF
--- a/src/v2/build.rs
+++ b/src/v2/build.rs
@@ -18,6 +18,10 @@ pub struct Build {
             deserialize_with = "deserialize_map_or_key_value_list")]
     pub args: BTreeMap<String, RawOr<String>>,
 
+    /// The FROM target at which to stop building
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<RawOr<String>>,
+
     /// PRIVATE.  Mark this struct as having unknown fields for future
     /// compatibility.  This prevents direct construction and exhaustive
     /// matching.  This needs to be be public because of
@@ -28,7 +32,7 @@ pub struct Build {
 }
 
 derive_standard_impls_for!(Build, {
-    context, dockerfile, args, _hidden
+    context, dockerfile, args, target, _hidden
 });
 
 impl Build {
@@ -50,6 +54,7 @@ impl Build {
             context: value(ctx.into()),
             dockerfile: Default::default(),
             args: Default::default(),
+            target: Default::default(),
             _hidden: (),
         }
     }

--- a/src/v2/file.rs
+++ b/src/v2/file.rs
@@ -99,7 +99,7 @@ impl File {
 impl Default for File {
     fn default() -> File {
         File {
-            version: "2".to_owned(),
+            version: "2.4".to_owned(),
             services: Default::default(),
             volumes: Default::default(),
             networks: Default::default(),


### PR DESCRIPTION
This requires docker-compose format >= v2.3 so the docker-compose.yml is
defaulted to version 2.4 (last 2.x release).

Docs: https://docs.docker.com/compose/compose-file/compose-file-v2/#target